### PR TITLE
Fix print() method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ License: MIT + file LICENSE
 Suggests:
     yaml,
     DiagrammeR,
-    testthat,
+    testthat (>= 2.1.0),
     V8,
     rsvg
 LazyData: TRUE

--- a/R/dm.R
+++ b/R/dm.R
@@ -618,9 +618,10 @@ print.data_model <- function(x, ...) {
   if(length(x$tables$table) > 4) {
     tables <- paste(tables, "...")
   }
-  cat(" ", nrow(x$tables), "tables: ", tables,"\n")
-  cat(" ", nrow(x$columns), "columns\n")
-  cat(" ", ifelse(is.null(x$references), "no", length(unique(x$references))),
+  cat(" ", NROW(x$tables), "tables: ", tables,"\n")
+  cat(" ", NROW(x$columns), "columns\n")
+  cat(" ", sum(x$columns[["key"]] != 0), "primary keys\n")
+  cat(" ", ifelse(is.null(x$references), "no", NROW(unique(x$references))),
       "references\n")
 }
 

--- a/R/dm.R
+++ b/R/dm.R
@@ -618,10 +618,10 @@ print.data_model <- function(x, ...) {
   if(length(x$tables$table) > 4) {
     tables <- paste(tables, "...")
   }
-  cat(" ", NROW(x$tables), "tables: ", tables,"\n")
-  cat(" ", NROW(x$columns), "columns\n")
+  cat(" ", nrow(x$tables), "tables: ", tables,"\n")
+  cat(" ", nrow(x$columns), "columns\n")
   cat(" ", sum(x$columns[["key"]] != 0), "primary keys\n")
-  cat(" ", ifelse(is.null(x$references), "no", NROW(unique(x$references))),
+  cat(" ", ifelse(is.null(x$references), "no", nrow(unique(x$references))),
       "references\n")
 }
 

--- a/tests/testthat/out/example.txt
+++ b/tests/testthat/out/example.txt
@@ -1,0 +1,5 @@
+Data model object:
+  4 tables:  Person, Order, Order Line, Item 
+  24 columns
+  5 primary keys
+  4 references

--- a/tests/testthat/test_dm.R
+++ b/tests/testthat/test_dm.R
@@ -69,6 +69,8 @@ test_that("Example yaml", {
   expect_is(dm, "data_model")
   expect_gt(nrow(dm$columns), 5)
   expect_gt(nrow(dm$references), 1)
+
+  expect_known_output(print(dm), "out/example.txt")
 })
 
 


### PR DESCRIPTION
Previously, the number of references was wrong:

```
Data model object:
  4 tables:  Person, Order, Order Line, Item 
  24 columns
  6 references
```

Also added number of primary keys to the output.