### PR TITLE
update print method for compound primary keys

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -620,7 +620,7 @@ print.data_model <- function(x, ...) {
   }
   cat(" ", nrow(x$tables), "tables: ", tables,"\n")
   cat(" ", nrow(x$columns), "columns\n")
-  cat(" ", sum(x$columns[["key"]] != 0), "primary keys\n")
+  cat(" ", length(unique(x$columns[x$columns[["key"]] != 0,"table"])), "primary keys\n")
   cat(" ", ifelse(is.null(x$references), "no", nrow(unique(x$references))),
       "references\n")
 }

--- a/R/dm.R
+++ b/R/dm.R
@@ -620,7 +620,7 @@ print.data_model <- function(x, ...) {
   }
   cat(" ", NROW(x$tables), "tables: ", tables,"\n")
   cat(" ", NROW(x$columns), "columns\n")
-  cat(" ", length(unique(x$columns[x$columns[["key"]] != 0,"table"])), "primary keys\n")
+  cat(" ", sum(x$columns[["key"]] != 0), "primary keys\n")
   cat(" ", ifelse(is.null(x$references), "no", NROW(unique(x$references))),
       "references\n")
 }

--- a/R/dm.R
+++ b/R/dm.R
@@ -620,7 +620,7 @@ print.data_model <- function(x, ...) {
   }
   cat(" ", NROW(x$tables), "tables: ", tables,"\n")
   cat(" ", NROW(x$columns), "columns\n")
-  cat(" ", sum(x$columns[["key"]] != 0), "primary keys\n")
+  cat(" ", length(unique(x$columns[x$columns[["key"]] != 0,"table"])), "primary keys\n")
   cat(" ", ifelse(is.null(x$references), "no", NROW(unique(x$references))),
       "references\n")
 }


### PR DESCRIPTION
the former print method used to count the number of key columns, also when they belonged to the same table. 

Now it counts only the number of unique tables that have at least one key column.

``` r
library(datamodelr)
library(magrittr)

dm_from_data_frames(iris, mtcars) %>% dm_set_key("mtcars", c("mpg", "gear"))
#> Data model object:
#>   2 tables:  iris, mtcars 
#>   16 columns
#>   1 primary keys
#>   no references
```

<sup>Created on 2019-08-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>